### PR TITLE
Add ortmodule option to trainer

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -269,7 +269,7 @@ def rewrite_logs(d):
     return new_d
 
 
-def init_deepspeed(trainer, num_training_steps):
+def init_deepspeed(trainer, model, num_training_steps):
     """
     Init DeepSpeed, after converting any relevant Trainer's args into DeepSpeed configuration
 
@@ -283,7 +283,6 @@ def init_deepspeed(trainer, num_training_steps):
 
     args = trainer.args
     ds_config_file = args.deepspeed
-    model = trainer.model
 
     with io.open(ds_config_file, "r", encoding="utf-8") as f:
         config = json.load(f)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -894,9 +894,16 @@ class Trainer:
             num_update_steps_per_epoch = max_steps
 
         delay_optimizer_creation = self.sharded_ddp is not None and self.sharded_ddp != ShardedDDPOption.SIMPLE
+        model = self.model
+        if self.args.ortmodule:
+            from onnxruntime.training import ORTModule
+            logger.info("Converting to ORTModule ....")
+            model = ORTModule(self.model)
+            self.model = model._original_module
+            self.model_wrapped = model
         if self.args.deepspeed:
-            model, optimizer, lr_scheduler = init_deepspeed(self, num_training_steps=max_steps)
-            self.model = model.module
+            model, optimizer, lr_scheduler = init_deepspeed(self, model, num_training_steps=max_steps)
+            self.model = model.module._original_module if self.args.ortmodule else model.module
             self.model_wrapped = model  # will get further wrapped in DDP
             self.deepspeed = model  # DeepSpeedEngine object
             self.optimizer = optimizer

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -899,7 +899,6 @@ class Trainer:
             from onnxruntime.training import ORTModule
             logger.info("Converting to ORTModule ....")
             model = ORTModule(self.model)
-            self.model = model._original_module
             self.model_wrapped = model
         if self.args.deepspeed:
             model, optimizer, lr_scheduler = init_deepspeed(self, model, num_training_steps=max_steps)

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -263,6 +263,8 @@ class TrainingArguments:
         deepspeed (:obj:`str`, `optional`):
             Use `Deepspeed <https://github.com/microsoft/deepspeed>`__. This is an experimental feature and its API may
             evolve in the future. The value is the location of its json config file (usually ``ds_config.json``).
+        ortmodule (:obj:`bool`, `optional`):
+            Use `ORTModule <https://github.com/microsoft/onnxruntime>`__.
         label_smoothing_factor (:obj:`float`, `optional`, defaults to 0.0):
             The label smoothing factor to use. Zero means no label smoothing, otherwise the underlying onehot-encoded
             labels are changed from 0s and 1s to :obj:`label_smoothing_factor/num_labels` and :obj:`1 -
@@ -480,6 +482,10 @@ class TrainingArguments:
     deepspeed: Optional[str] = field(
         default=None,
         metadata={"help": "Enable deepspeed and pass the path to deepspeed json config file (e.g. ds_config.json)"},
+    )
+    ortmodule: Optional[bool] = field(
+        default=False,
+        metadata={"help": "Enable OrtModule"},
     )
     label_smoothing_factor: float = field(
         default=0.0, metadata={"help": "The label smoothing epsilon to apply (zero means no label smoothing)."}


### PR DESCRIPTION
# What does this PR do?
This PR adds an option to train with ortmodule. Usage:
Add `--ortmodule` to the command line args of your usual run command for pytorch/ deepspeed.
Tested for: T5 translation task.
Scenarios:
FP32- pytorch and ortmodule
`export BS=1; rm -r output_dir; CUDA_VISIBLE_DEVICES=1 PYTHONPATH=../../src USE_TF=0 ./run_seq2seq.py \
--source_prefix "translate English to Romanian: " --dataset_name wmt16 --dataset_config "ro-en" \
--model_name_or_path t5-small --output_dir output_dir --adam_eps 1e-06  --do_eval \
--do_predict --do_train --evaluation_strategy=steps  --label_smoothing 0.1 --learning_rate 3e-5 \
--logging_first_step --logging_steps 1000 --max_source_length 128 --max_target_length 128 --num_train_epochs 1 \
--overwrite_output_dir --per_device_eval_batch_size $BS --per_device_train_batch_size $BS --predict_with_generate \
--eval_steps 25000  --sortish_sampler --task translation_en_to_ro  \
--val_max_target_length 128 --warmup_steps 5 --max_train_samples 60 --max_val_samples 10 --max_test_samples 10 \
--ortmodule \`

FP16- Pytorch+Deepspeed fp16 and ortmodule
`export BS=1; rm -r output_dir; CUDA_VISIBLE_DEVICES=0 PYTHONPATH=../../src USE_TF=0 deepspeed --num_gpus=1 ./run_seq2seq.py \
--source_prefix "translate English to Romanian: " --dataset_name wmt16 --dataset_config "ro-en" \
--model_name_or_path t5-small --output_dir output_dir --adam_eps 1e-06  --do_eval \
--do_predict --do_train --evaluation_strategy=steps  --label_smoothing 0.1 --learning_rate 3e-5 \
--logging_first_step --logging_steps 1000 --max_source_length 128 --max_target_length 128 --num_train_epochs 1 \
--overwrite_output_dir --per_device_eval_batch_size $BS --per_device_train_batch_size $BS --predict_with_generate \
--eval_steps 25000  --sortish_sampler --task translation_en_to_ro  \
--val_max_target_length 128 --warmup_steps 5 --max_train_samples 60 --max_val_samples 10 --max_test_samples 10 --fp16 \
--deepspeed ds_config_1gpu.json \
--ortmodule \`

With Deepspeed config file:
`{
    "fp16": {
        "enabled": true,
        "loss_scale": 0,
        "loss_scale_window": 1000,
        "hysteresis": 2,
        "min_loss_scale": 1
    },
    "zero_optimization": {
        "stage": 0,
       "allgather_partitions": true,
       "allgather_bucket_size": 2e8,
       "reduce_scatter": true,
       "reduce_bucket_size": 2e8,
        "overlap_comm": true,
        "contiguous_gradients": true,
        "cpu_offload": false
    },
    "optimizer": {
        "type": "AdamW",
        "params": {
            "lr": 3e-5,
            "betas": [ 0.9, 0.999 ],
            "eps": 1e-8,
            "weight_decay": 3e-7
        }
    },
    "scheduler": {
        "type": "WarmupLR",
        "params": {
            "warmup_min_lr": 0,
            "warmup_max_lr": 3e-5,
            "warmup_num_steps": 500
        }
    }
}
`